### PR TITLE
user options for font size and compact modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A modern, tabbed UI for Hyper-V.
 ## User Settings 
 
 User settings are stored in `vmplex-settings.json`. It is generated and managed by the application.
-You may edit the settings at runtime.
+You may edit the settings at runtime. The settings are documented [here](VMPlex/UserSettings.cs).
 
 ### Debugger Launch Support
 

--- a/VMPlex/UI/ManagerPage.xaml
+++ b/VMPlex/UI/ManagerPage.xaml
@@ -129,21 +129,20 @@
                         <GridViewColumn Header="Process ID"
                                         DisplayMemberBinding="{Binding ProcessID, Converter={StaticResource VMPidConverter}}"
                                         HeaderTemplate="{StaticResource HeaderTempl}"
-                                        Width="83"
+                                        Width="94"
                                         util:GridViewSort.PropertyName="ProcessID"/>
                     </GridView>
                 </ListView.View>
                 <ListView.ItemContainerStyle>
                     <Style TargetType="ListViewItem" BasedOn="{StaticResource DefaultListViewItemStyle}">
+                        <Setter Property="FontSize" Value="14" />
+                        <Setter Property="Padding" Value="10" />
+                        <Setter Property="MinHeight" Value="2" />
                         <Setter Property="Template">
                             <Setter.Value>
                                 <ControlTemplate TargetType="ListViewItem">
                                     <Border x:Name="Bd" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="true">
                                         <Grid>
-                                            <Grid.RowDefinitions>
-                                                <RowDefinition MaxHeight="11"/>
-                                                <RowDefinition />
-                                            </Grid.RowDefinitions>
                                             <GridViewRowPresenter x:Name="ContentPresenter" Grid.RowSpan="2" 
                                                     VerticalAlignment="{TemplateBinding VerticalContentAlignment}" 
                                                     SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />

--- a/VMPlex/UI/ManagerPage.xaml.cs
+++ b/VMPlex/UI/ManagerPage.xaml.cs
@@ -2,6 +2,7 @@
  * Copyright (c) 2022 Ira Strawser. All rights reserved.
  */
 
+using ABI.Windows.ApplicationModel.Activation;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -24,12 +25,14 @@ namespace VMPlex.UI
         public ManagerPage()
         {
             InitializeComponent();
+            SetUserDisplayPreferences(App.UserSettings.Get());
             vmList.DataContext = VMManager.Instance.VirtualMachines;
             vmGrid.DataContext = VMManager.Instance.VirtualMachines;
             VMManager.Instance.OnVmDeleted += VmDeleted;
             SetValue(TextOptions.TextFormattingModeProperty, TextFormattingMode.Display);
             SetValue(FontFamilyProperty, SystemFonts.MessageFontFamily);
             SetValue(FontSizeProperty, SystemFonts.MessageFontSize);
+            App.UserSettings.SettingsChanged += SettingsChanged;
         }
 
         private void OpenVmTab(VirtualMachine vm, TabControl tc)
@@ -276,6 +279,37 @@ namespace VMPlex.UI
                 }
                 vm.DeleteFromServer();
             }
+        }
+
+        private void SettingsChanged(Settings UserSettings)
+        {
+            Dispatcher.Invoke(() =>
+            {
+                SetUserDisplayPreferences(UserSettings);
+            });
+        }
+
+        private void SetUserDisplayPreferences(Settings UserSettings)
+        {
+            var itemStyle = new Style
+            {
+                TargetType = typeof(ListViewItem),
+                BasedOn = vmList.ItemContainerStyle
+            };
+
+            if (UserSettings.FontSize != null)
+            {
+                itemStyle.Setters.Add(new Setter(ListViewItem.FontSizeProperty, UserSettings.FontSize));
+            }
+            else
+            {
+                itemStyle.Setters.Add(new Setter(ListViewItem.FontSizeProperty, 14.0));
+            }
+
+            var thicc = new Thickness(UserSettings.CompactMode ? 2.0 : 10.0);
+            itemStyle.Setters.Add(new Setter(ListViewItem.PaddingProperty, thicc));
+
+            vmList.ItemContainerStyle = itemStyle;
         }
     }
 


### PR DESCRIPTION
Adds user options for compact modes and setting the font size. At this time it only applies to the manager list view.

![image](https://user-images.githubusercontent.com/11687482/197701112-433e0a8b-1e84-4f19-bda7-0f86f834d4e0.png)

```json
{
    "CompactMode": true,
    "FontSize": 12
}
```

