### PR TITLE
Enable per-monitor DPI awareness, fix some issues with mixed DPI

### DIFF
--- a/VMPlex/Rdp/RdpClient.cs
+++ b/VMPlex/Rdp/RdpClient.cs
@@ -104,7 +104,7 @@ namespace VMPlex
 
             SecuredSettings2.KeyboardHookMode = 1; // apply remotely (fixes windows key, alt-tab, etc)
 
-            SetExtendedProperty("DesktopScaleFactor", GetDesktopScaleFactor());
+            SetExtendedProperty("DesktopScaleFactor", 100u);
             SetExtendedProperty("DeviceScaleFactor", 100u);
 
             if (options.HardwareAssist)

--- a/VMPlex/app.manifest
+++ b/VMPlex/app.manifest
@@ -43,14 +43,15 @@
        also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. 
        
        Makes the application long-path aware. See https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation -->
-  <!--
+
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+	  <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
       <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
     </windowsSettings>
   </application>
-  -->
+
   <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
   <dependency>
     <dependentAssembly>


### PR DESCRIPTION
This pull request enables per-monitor DPI awareness, and fixes a few issues observed with mixed DPI environments. Properly covering all cases will require a batch of improvements, the current code appears to be using a timer for resizing, and the current code for the enhanced session mode is just broken for me. I suggest we get the client-side DPI awareness doing right in a first step, and only then try to correctly forward DPI scaling information to the RDP server. Not all RDP connections support DPI scaling information - anything prior to Windows 8.1 won't accept it, but also the Hyper-V basic session mode, and Hyper-V with the framebuffer redirection.