### PR TITLE
compact mode additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ bin/
 VMPlex/obj/
 hvintegrate/obj/
 
+vmplex-settings.json
+

--- a/VMPlex/UI/ManagerPage.xaml
+++ b/VMPlex/UI/ManagerPage.xaml
@@ -17,11 +17,31 @@
         <DataTemplate x:Key="VmTemplate">
             <Button MouseDoubleClick="VmTemplate_MouseDoubleClick" Background="{DynamicResource SystemControlBackgroundAltMediumLowBrush}">
                 <StackPanel Orientation="Vertical">
-                    <Border BorderThickness="1" Margin="5,25,5,10" Width="318" Height="238" BorderBrush="{DynamicResource SystemControlPageTextBaseHighBrush}">
+                    <Border BorderThickness="1" BorderBrush="{DynamicResource SystemControlPageTextBaseHighBrush}">
+                        <Border.Style>
+                            <Style TargetType="Border">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Source={x:Static root:UserSettings.Instance}, Path=Settings.CompactMode, UpdateSourceTrigger=PropertyChanged}"
+                                                 Value="True">
+                                        <Setter Property="Width" Value="160" />
+                                        <Setter Property="Height" Value="120" />
+                                        <Setter Property="Margin" Value="0,5,0,5" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding Source={x:Static root:UserSettings.Instance}, Path=Settings.CompactMode, UpdateSourceTrigger=PropertyChanged}"
+                                                 Value="False">
+                                        <Setter Property="Width" Value="320" />
+                                        <Setter Property="Height" Value="240" />
+                                        <Setter Property="Margin" Value="5,25,5,10" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
                         <Image Grid.Row="0" Stretch="Fill" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Source="{Binding Thumbnail}"/>
                     </Border>
-                    <TextBlock Text="{Binding Name}" HorizontalAlignment="Center" FontWeight="Bold" FontSize="13"/>
-                    <TextBlock Text="{Binding State}" HorizontalAlignment="Center" FontWeight="Normal" FontSize="11"/>
+                    <TextBlock Text="{Binding Name}" HorizontalAlignment="Center" FontWeight="Bold" 
+                               FontSize="{Binding Source={x:Static root:UserSettings.Instance}, Path=Settings.FontSize, UpdateSourceTrigger=PropertyChanged}"/>
+                    <TextBlock Text="{Binding State}" HorizontalAlignment="Center" FontWeight="Normal" 
+                               FontSize="{Binding Source={x:Static root:UserSettings.Instance}, Path=Settings.FontSize, UpdateSourceTrigger=PropertyChanged}"/>
                 </StackPanel>
             </Button>
         </DataTemplate>
@@ -93,9 +113,6 @@
             </Grid.ColumnDefinitions>
             <ListView Grid.Column="0" x:Name="vmList" ItemsSource="{Binding}" util:GridViewSort.AutoSort="True">
                 <ListView.Resources>
-                    <DataTemplate x:Key="HeaderTempl">
-                        <TextBlock HorizontalAlignment="Left" Text="{Binding}" Margin="5,0,0,0"/>
-                    </DataTemplate>
                     <Style x:Key="ContextMenuItemStyle" TargetType="MenuItem">
                         <Setter Property="FontSize" Value="14" />
                         <Setter Property="Margin" Value="5,0,5,0" />
@@ -149,34 +166,38 @@
                 </ListView.Resources>
                 <ListView.View>
                     <GridView>
+                        <GridView.ColumnHeaderContainerStyle>
+                            <Style TargetType="GridViewColumnHeader" BasedOn="{StaticResource {x:Type GridViewColumnHeader}}">
+                                <Setter Property="FontSize" Value="{Binding Source={x:Static root:UserSettings.Instance}, Path=Settings.FontSize, UpdateSourceTrigger=PropertyChanged}" />
+                            </Style>
+                        </GridView.ColumnHeaderContainerStyle>
+                        <GridView.ColumnHeaderTemplate>
+                            <DataTemplate>
+                                <TextBlock HorizontalAlignment="Left" Text="{Binding}" Margin="5,0,0,0"/>
+                            </DataTemplate>
+                        </GridView.ColumnHeaderTemplate>
                         <GridViewColumn Header="Name"
                                         DisplayMemberBinding="{Binding Name}"
-                                        HeaderTemplate="{StaticResource HeaderTempl}"
                                         Width="170"
                                         util:GridViewSort.PropertyName="Name"/>
                         <GridViewColumn Header="Status"
                                         DisplayMemberBinding="{Binding State}"
-                                        HeaderTemplate="{StaticResource HeaderTempl}"
                                         Width="75"
                                         util:GridViewSort.PropertyName="State"/>
                         <GridViewColumn Header="Cpu Usage (Host)"
                                         DisplayMemberBinding="{Binding Self, Converter={StaticResource VMCpuUsageConverter}}"
-                                        HeaderTemplate="{StaticResource HeaderTempl}"
                                         Width="148"
                                         util:GridViewSort.PropertyName="ProcessorLoad"/>
                         <GridViewColumn Header="Assigned Memory"
                                         DisplayMemberBinding="{Binding Self, Converter={StaticResource VMMemoryConverter}}"
-                                        HeaderTemplate="{StaticResource HeaderTempl}"
                                         Width="150"
                                         util:GridViewSort.PropertyName="MemoryUsage"/>
                         <GridViewColumn Header="Uptime"
                                         DisplayMemberBinding="{Binding Self, Converter={StaticResource VMUptimeConverter}}"
-                                        HeaderTemplate="{StaticResource HeaderTempl}"
                                         Width="83"
                                         util:GridViewSort.PropertyName="UpTime"/>
                         <GridViewColumn Header="Process ID"
                                         DisplayMemberBinding="{Binding ProcessID, Converter={StaticResource VMPidConverter}}"
-                                        HeaderTemplate="{StaticResource HeaderTempl}"
                                         Width="94"
                                         util:GridViewSort.PropertyName="ProcessID"/>
                     </GridView>

--- a/VMPlex/UI/VmInfoPanel.xaml
+++ b/VMPlex/UI/VmInfoPanel.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:root="clr-namespace:VMPlex"
              xmlns:local="clr-namespace:VMPlex.UI"
              xmlns:system="clr-namespace:System;assembly=mscorlib"
              mc:Ignorable="d">
@@ -14,7 +15,16 @@
             <ListView.ItemContainerStyle>
                 <Style TargetType="ListViewItem" BasedOn="{StaticResource DefaultListViewItemStyle}">
                     <Setter Property="Focusable" Value="False"/>
-                    <Setter Property="Margin" Value="-4"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding Source={x:Static root:UserSettings.Instance}, Path=Settings.CompactMode, UpdateSourceTrigger=PropertyChanged}"
+                                     Value="True">
+                            <Setter Property="Margin" Value="-8"/>
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding Source={x:Static root:UserSettings.Instance}, Path=Settings.CompactMode, UpdateSourceTrigger=PropertyChanged}"
+                                     Value="False">
+                            <Setter Property="Margin" Value="-4"/>
+                        </DataTrigger>
+                    </Style.Triggers>
                 </Style>
             </ListView.ItemContainerStyle>
             <ListViewItem>
@@ -51,7 +61,25 @@
                 </StackPanel>
             </ListViewItem>
         </ListView>
-        <Border BorderThickness="1" Margin="5,25,5,25" Width="318" Height="238" BorderBrush="{DynamicResource SystemControlPageTextBaseHighBrush}">
+        <Border BorderThickness="1" BorderBrush="{DynamicResource SystemControlPageTextBaseHighBrush}">
+            <Border.Style>
+                <Style TargetType="Border">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding Source={x:Static root:UserSettings.Instance}, Path=Settings.CompactMode, UpdateSourceTrigger=PropertyChanged}"
+                                     Value="True">
+                            <Setter Property="Width" Value="400" />
+                            <Setter Property="Height" Value="300" />
+                            <Setter Property="Margin" Value="0,5,0,5" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding Source={x:Static root:UserSettings.Instance}, Path=Settings.CompactMode, UpdateSourceTrigger=PropertyChanged}"
+                                     Value="False">
+                            <Setter Property="Width" Value="400" />
+                            <Setter Property="Height" Value="300" />
+                            <Setter Property="Margin" Value="5,25,5,10" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Border.Style>
             <Image Grid.Row="0" Stretch="Fill" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Source="{Binding Thumbnail}"/>
         </Border>
     </StackPanel>


### PR DESCRIPTION
This extends the functionality around "CompactMode" which should help people who have a large number of VMs to better manage/view them:

Normal:
![image](https://user-images.githubusercontent.com/11687482/198162524-01014d4d-b65f-48a4-b455-4af35d61d36b.png)

Compact:
![image](https://user-images.githubusercontent.com/11687482/198162565-7de015ee-0277-4ecb-98ae-6dcd8f6191cb.png)
