### PR TITLE
add vm rdp user options

### DIFF
--- a/VMPlex/Rdp/RdpClient.cs
+++ b/VMPlex/Rdp/RdpClient.cs
@@ -99,9 +99,12 @@ namespace VMPlex
             AdvancedSettings6.RedirectPorts = m_options.RedirectPorts;
             AdvancedSettings6.RedirectSmartCards = m_options.RedirectSmartCards;
             AdvancedSettings6.RedirectPOSDevices = false;
+            AdvancedSettings6.AudioRedirectionMode = options.AudioRedirectionMode;
 
             AdvancedSettings7.AuthenticationServiceClass = "Microsoft Virtual Console Service";
             AdvancedSettings7.RelativeMouseMode = true;
+
+            AdvancedSettings8.AudioCaptureRedirectionMode = options.AudioCaptureRedirectionMode;
 
             SecuredSettings2.KeyboardHookMode = 1; // apply remotely (fixes windows key, alt-tab, etc)
 

--- a/VMPlex/Rdp/RdpOptions.cs
+++ b/VMPlex/Rdp/RdpOptions.cs
@@ -31,6 +31,8 @@ namespace VMPlex
             RedirectDevices = false;
             RedirectPorts = false;
             RedirectSmartCards = false;
+            AudioRedirectionMode = 0;
+            AudioCaptureRedirectionMode = false;
         }
 
         public string Server { get; set; }
@@ -52,5 +54,7 @@ namespace VMPlex
         public bool RedirectDevices { get; set; }
         public bool RedirectPorts { get; set; }
         public bool RedirectSmartCards { get; set; }
+        public uint AudioRedirectionMode { get; set; }
+        public bool AudioCaptureRedirectionMode { get; set; }
     }
 }

--- a/VMPlex/UI/VmRdpPage.xaml.cs
+++ b/VMPlex/UI/VmRdpPage.xaml.cs
@@ -29,10 +29,62 @@ namespace VMPlex.UI
             m_vm = vmModel;
 
             InitializeComponent();
-            Connect(vmModel, enhanced);
+            Connect(enhanced);
         }
 
-        private void Connect(VirtualMachine vmModel, bool enhanced)
+        private RdpOptions MakeRdpOptions()
+        {
+            var options = new RdpOptions();
+            var userOpts = m_vm.GetVmUserSettings().RdpSettings;
+            if (userOpts == null)
+            {
+                return options;
+            }
+
+            if (userOpts.RedirectClipboard != null)
+            {
+                options.RedirectClipboard = (bool)userOpts.RedirectClipboard;
+            }
+
+            if (userOpts.AudioRedirectionMode != null)
+            {
+                options.AudioRedirectionMode = (uint)userOpts.AudioRedirectionMode;
+            }
+
+            if (userOpts.AudioCaptureRedirectionMode != null)
+            {
+                options.AudioCaptureRedirectionMode = (bool)userOpts.AudioCaptureRedirectionMode;
+            }
+
+            if (userOpts.RedirectDrives != null)
+            {
+                options.RedirectDrives = (bool)userOpts.RedirectDrives;
+            }
+
+            if (userOpts.RedirectDevices != null)
+            {
+                options.RedirectDevices = (bool)userOpts.RedirectDevices;
+            }
+
+            if (userOpts.RedirectSmartCards != null)
+            {
+                options.RedirectSmartCards = (bool)userOpts.RedirectSmartCards;
+            }
+
+            if (userOpts.DesktopWidth != null)
+            {
+                options.DesktopWidth = (int)userOpts.DesktopWidth;
+            }
+
+            if (userOpts.DesktopHeight != null)
+            {
+                options.DesktopHeight = (int)userOpts.DesktopHeight;
+            }
+
+            return options;
+        }
+
+        private void Connect(bool enhanced)
         {
             m_prevVideoAvail = m_vm.IsVideoAvailable();
             m_prevEnhancedState = m_vm.EnhancedSessionModeState;
@@ -43,8 +95,9 @@ namespace VMPlex.UI
             rdpHost.DpiChanged += RdpHost_DpiChanged;
             rdp.DesktopResized += OnRdpDesktopResized;
 
-            RdpOptions options = new RdpOptions();
+            RdpOptions options = MakeRdpOptions();
             options.EnhancedSession = enhanced;
+
             rdp.InitializeForLocalVmConnection(m_vm, options);
 
             m_vm.PropertyChanged += VmModel_PropertyChanged;
@@ -56,10 +109,10 @@ namespace VMPlex.UI
             vmEnhancedMode.Checked -= OnEnhancedChecked;
             vmEnhancedMode.Unchecked -= OnEnhancedUnchecked;
             offlineText.Visibility = System.Windows.Visibility.Visible;
-            if (vmModel.IsVideoAvailable())
+            if (m_vm.IsVideoAvailable())
             {
                 rdp.Connect();
-                vmEnhancedMode.IsChecked = enhanced && vmModel.EnhancedSessionModeState != Msvm_ComputerSystem.EnhancedSessionMode.NotAllowed;
+                vmEnhancedMode.IsChecked = enhanced && m_vm.EnhancedSessionModeState != Msvm_ComputerSystem.EnhancedSessionMode.NotAllowed;
             }
             else
             {

--- a/VMPlex/UserSettings.cs
+++ b/VMPlex/UserSettings.cs
@@ -15,6 +15,7 @@ using System.Text.Json.Serialization;
 namespace VMPlex
 {
 
+#nullable enable 
     /// <summary>
     /// Root of the user settings. Configured via vmplex-settings.json.
     /// </summary>
@@ -58,14 +59,14 @@ namespace VMPlex
         /// populate this on the user's behalf.
         /// </summary>
         [JsonInclude]
-        public string Guid { get; set; }
+        public string Guid { get; set; } = "";
 
         /// <summary>
         /// The friendly name of the virtual machine as reported by Hyper-V.
         /// VMPlex will populate this on this user's behalf.
         /// </summary>
         [JsonInclude]
-        public string Name { get; set; }
+        public string Name { get; set; } = "";
 
         /// <summary>
         /// Arguments passed to the debugger when launching one for a given
@@ -75,8 +76,96 @@ namespace VMPlex
         /// References the documentation for your debugger. 
         /// </summary>
         [JsonInclude]
-        public string DebuggerArguments { get; set; }
+        public string DebuggerArguments { get; set; } = "";
+
+        /// <summary>
+        /// Optional RDP settings used when connecting to this virtual machine.
+        /// </summary>
+        [JsonInclude]
+        public RdpSettings? RdpSettings { get; set; } = null;
     }
+
+    /// <summary>
+    /// User settings for a RDP connections. 
+    /// </summary>
+    public class RdpSettings
+    {
+        /// <summary>
+        /// Specifies if redirection of the clipboard is allowed.
+        /// </summary>
+        [JsonInclude]
+        public bool? RedirectClipboard { get; set; } = null;
+
+        /// <summary>
+        /// Values for the audio redirection mode.
+        /// </summary>
+        public enum AudioRedirectionModeSetting
+        {
+            /// <summary>
+            /// Audio redirection is enabled and the option for redirection is
+            /// "Bring to this computer". This is the default mode.
+            /// </summary>
+            Redirect = 0,
+
+            /// <summary>
+            /// Audio redirection is enabled and the option is "Leave at
+            /// remote computer". The "Leave at remote computer" option is
+            /// supported only when connecting remotely to a host computer
+            /// that is running Windows Vista. If the connection is to a host
+            /// computer that is running Windows Server 2008, the option 
+            /// "Leave at remote computer" is changed to "Do not play".
+            /// </summary>
+            PlayOnServer = 1,
+
+            /// <summary>
+            /// Audio redirection is enabled and the mode is "Do not play".
+            /// </summary>
+            None = 2
+        }
+
+        /// <summary>
+        /// Sets different values for the audio redirection mode. 
+        /// </summary>
+        [JsonInclude]
+        public AudioRedirectionModeSetting? AudioRedirectionMode { get; set; } = null;
+
+        /// <summary>
+        /// Specifies if the default audio input device is captured.
+        /// </summary>
+        [JsonInclude]
+        public bool? AudioCaptureRedirectionMode { get; set; } = null;
+
+        /// <summary>
+        /// Specifies if redirection of disk drives is allowed.
+        /// </summary>
+        [JsonInclude]
+        public bool? RedirectDrives { get; set; } = null;
+
+        /// <summary>
+        /// Specifies if redirection of devices is allowed.
+        /// </summary>
+        [JsonInclude]
+        public bool? RedirectDevices { get; set; } = null;
+
+        /// <summary>
+        /// Specifies if redirection of smart cards is allowed.
+        /// </summary>
+        [JsonInclude]
+        public bool? RedirectSmartCards { get; set; } = null;
+
+        /// <summary>
+        /// Specifies the initial remote desktop width, in pixels.
+        /// </summary>
+        [JsonInclude]
+        public int? DesktopWidth { get; set; } = null;
+
+        /// <summary>
+        /// Specifies the initial remote desktop height, in pixels.
+        /// </summary>
+        [JsonInclude]
+        public int? DesktopHeight { get; set; } = null;
+    }
+#nullable restore 
 
     public class UserSettings : INotifyPropertyChanged
     {
@@ -184,7 +273,7 @@ namespace VMPlex
                 else
                 {
                     var json = File.ReadAllText(UserSettingsFile);
-                    ActiveSettings = JsonSerializer.Deserialize<Settings>(json);
+                    ActiveSettings = JsonSerializer.Deserialize<Settings>(json, JsonSerializeOpts);
                 }
             }
         }
@@ -255,7 +344,11 @@ namespace VMPlex
         private JsonSerializerOptions JsonSerializeOpts = new JsonSerializerOptions
         {
             WriteIndented = true,
-            IncludeFields = true
+            IncludeFields = true,
+            Converters =
+            {
+                new JsonStringEnumConverter()
+            }
         };
         private DateTime LastReloadErrorTime = DateTime.Now;
     }


### PR DESCRIPTION
This adds user options for configuring the RDP options for a given virtual machine. These are under the "RdpSettings", for example:

```json
{
  "CompactMode": true,
  "FontSize": 14,
  "Debugger": "",
  "VirtualMachines": [
    {
      "Guid": "00000000-0000-0000-0000-00000000000",
      "Name": "WIN11X64",
      "DebuggerArguments": "",
      "RdpSettings": {
        "RedirectClipboard": false,
        "AudioRedirectionMode": "None",
        "AudioCaptureRedirectionMode": false,
        "RedirectDrives": true,
        "RedirectDevices": true,
        "RedirectSmartCards": true,
        "DesktopWidth": 64,
        "DesktopHeight": 64
      }
    }
  ]
}
```