### PR TITLE
Protect against basic sessions against shielded VMs

### DIFF
--- a/VMPlex/UI/VmRdpPage.xaml
+++ b/VMPlex/UI/VmRdpPage.xaml
@@ -73,6 +73,14 @@
             <StackPanel VerticalAlignment="Center">
             <Label x:Name="offlineText" Content="{Binding State}" Foreground="LightGray" Background="Transparent" FontFamily="Segoe UI" FontSize="30" HorizontalAlignment="Center" Visibility="Visible"/>
             <Label x:Name="connectingText" Content="{Binding Name}" ContentStringFormat="(Connecting to {0}...)" Foreground="LightGray" Background="Transparent" FontFamily="Segoe UI" FontSize="20" HorizontalAlignment="Center" Visibility="Hidden"/>
+            <TextBlock x:Name="errorText"
+                   Text="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:UI.VmRdpPage}}, Path=ErrorMessage}"
+                   TextAlignment="Center"
+                   Foreground="LightGray"
+                   Background="Transparent"
+                   FontFamily="Segoe UI"
+                   FontSize="18"
+                   Visibility="Hidden"/>
             </StackPanel>
         </Grid>
     </Grid>

--- a/VMPlex/VirtualMachine.cs
+++ b/VMPlex/VirtualMachine.cs
@@ -9,6 +9,7 @@ using System.Management;
 using System.Windows.Media.Imaging;
 using System.Diagnostics;
 using VMPlex.WMI;
+using ORMi;
 
 namespace VMPlex
 {
@@ -114,7 +115,7 @@ namespace VMPlex
             process.StartInfo = new ProcessStartInfo()
             {
                 FileName = settings.Debugger,
-                Arguments = vm.DebuggerArguments, 
+                Arguments = vm.DebuggerArguments,
                 UseShellExecute = true
             };
 
@@ -376,6 +377,7 @@ namespace VMPlex
         public string Guid { get; set; }
         public string Version { get; set; }
         public uint ProcessID { get; set; }
+        public Msvm_SecurityElement SecurityElement{ get { return Msvm.SecurityElement; } }
         public Msvm_ComputerSystem.SystemState State { get; set; }
         public bool IsRunning {
             get

--- a/VMPlex/WMI/Msvm_ComputerSystem.cs
+++ b/VMPlex/WMI/Msvm_ComputerSystem.cs
@@ -63,6 +63,28 @@ namespace VMPlex.WMI
 
         public EnhancedSessionMode EnhancedSessionModeState { get; set; }
 
+        [WMIIgnore]
+        public Msvm_SecurityElement SecurityElement
+        {
+            get {
+                ManagementObjectCollection securityElements = GetVm(Guid).GetRelated(
+                    "Msvm_SecurityElement",
+                    "Msvm_SystemComponent",
+                    null,
+                    null,
+                    null,
+                    null,
+                    false,
+                    null);
+
+                foreach (ManagementObject instance in securityElements)
+                {
+                    return (Msvm_SecurityElement)ORMi.Helpers.TypeHelper.LoadObject(instance, typeof(Msvm_SecurityElement));
+                }
+                return null;
+            }
+        }
+
         public uint RequestStateChange(ushort state)
         {
             ManagementObject mo = GetVm(Guid);

--- a/VMPlex/WMI/Msvm_SecurityElement.cs
+++ b/VMPlex/WMI/Msvm_SecurityElement.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ORMi;
+
+namespace VMPlex.WMI
+{
+    [WMIClass(Name = "Msvm_SecurityElement", Namespace = @"root\Virtualization\V2")]
+    public class Msvm_SecurityElement : WMIInstance
+    {
+        [WMIProperty("Shielded")]
+        public bool Shielded { get; set; }
+
+        [WMIProperty("EncryptStateAndVmMigrationTrafficEnabled")]
+        public bool EncryptStateAndVmMigrationTrafficEnabled { get; set; }
+    }
+}


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/56487417/198369053-b55f00e4-a8ad-42d0-ad95-54581d645c2f.png)

Also adds an "ErrorMessage" property on VmRdpPage that can be used for errors that prevent the rdp control from being functional. The property is bound in the VmRdpPage xaml in an "errorText" textblock.