### PR TITLE
add user settings schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pubxml.user
 
 .vs/
+.vscode/
 bin/
 VMPlex/obj/
 hvintegrate/obj/

--- a/VMPlex/App.xaml.cs
+++ b/VMPlex/App.xaml.cs
@@ -21,6 +21,7 @@ namespace VMPlex
             try
             {
                 UserSettings.Instance.Load();
+                UserSettings.Instance.Save();
             }
             catch (Exception exc)
             {

--- a/VMPlex/UserSettings.cs
+++ b/VMPlex/UserSettings.cs
@@ -20,6 +20,9 @@ namespace VMPlex
     /// </summary>
     public class Settings
     {
+        [JsonInclude, JsonPropertyOrder(-1), JsonPropertyName("$schema")]
+        public string _schema = "https://raw.githubusercontent.com/0xf005ba11/vmplex-ws/main/VMPlex/UserSettingsSchema.json";
+
         /// <summary>
         /// If true portions of the interface are styled in a compact style. 
         /// </summary>
@@ -54,7 +57,7 @@ namespace VMPlex
     public class VmConfig
     {
         /// <summary>
-        /// The GUID of the virtual machine at reported by Hyper-V. VMPlex will
+        /// The GUID of the virtual machine as reported by Hyper-V. VMPlex will
         /// populate this on the user's behalf.
         /// </summary>
         [JsonInclude]
@@ -68,7 +71,7 @@ namespace VMPlex
         public string Name { get; set; } = "";
 
         /// <summary>
-        /// Arguments passed to the debugger when launching one for a given
+        /// Arguments passed to the debugger when launching one for this 
         /// virtual machine. As an example, when using windbg and debugging
         /// the target virtual machine over the network this would be in a
         /// form similar to "-k net:port=50000,key=1.2.3.4 -T WIN11X64".
@@ -265,7 +268,17 @@ namespace VMPlex
                 {
                     var json = File.ReadAllText(UserSettingsFile);
                     ActiveSettings = JsonSerializer.Deserialize<Settings>(json, JsonSerializeOpts);
+                    ActiveSettings._schema = (new Settings())._schema;
                 }
+            }
+        }
+
+        public void Save()
+        {
+            lock (Lock)
+            {
+                var json = JsonSerializer.Serialize(ActiveSettings, JsonSerializeOpts);
+                File.WriteAllText(UserSettingsFile, json);
             }
         }
 

--- a/VMPlex/UserSettingsSchema.json
+++ b/VMPlex/UserSettingsSchema.json
@@ -1,0 +1,104 @@
+{
+    "$id": "https://raw.githubusercontent.com/0xf005ba11/vmplex-ws/main/VMPlex/UserSettingsSchema.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "VMPlex Workstation User Settings",
+    "type": "object",
+    "properties": {
+        "CompactMode": {
+            "type": "boolean",
+            "default": "false",
+            "description": "If true portions of the interface are styled in a compact style."
+        },
+        "FontSize": {
+            "type": "number",
+            "default": 14,
+            "description": "Optionally sets the font size for certain elements of the UI."
+        },
+        "Debugger": {
+            "type": "string",
+            "default": "windbgx",
+            "description": "Defines the debugger to use when launching one for a given virtual machine."
+        },
+        "VirtualMachines": {
+            "type": "array",
+            "description": "A list of virtual machines.",
+            "items": {
+                "type": "object",
+                "description": "User settings for a given virtual machine.",
+                "properties": {
+                    "Guid": {
+                        "type": "string",
+                        "default": "",
+                        "description": "The GUID of the virtual machine as reported by Hyper-V."
+                    },
+                    "Name": {
+                        "type": "string",
+                        "default": "",
+                        "description": "The friendly name of the virtual machine as reported by Hyper-V."
+                    },
+                    "DebuggerArguments": {
+                        "type": "string",
+                        "default": "",
+                        "description": "Arguments passed to the debugger when launching one for this virtual machine."
+                    },
+                    "RdpSettings": {
+                        "type": "object",
+                        "description": "Optional RDP settings used when connecting to this virtual machine.",
+                        "properties": {
+                            "DefaultEnhancedSession": {
+                                "type": "boolean",
+                                "default": true,
+                                "description": "The default enhanced session state when connecting to a virtual machine."
+                            },
+                            "RedirectClipboard": {
+                                "type": "boolean",
+                                "default": true,
+                                "description": "Specifies if redirection of the clipboard is allowed."
+                            },
+                            "AudioRedirectionMode": {
+                                "type": "string",
+                                "enum": [
+                                    "Redirect",
+                                    "PlayOnServer",
+                                    "None"
+                                ],
+                                "default": "Redirect",
+                                "description": "Specifies the auto redirection mode."
+                            },
+                            "AudioCaptureRedirectionMode": {
+                                "type": "boolean",
+                                "default": false,
+                                "description": "Specifies if the default audio input device is captured."
+                            },
+                            "RedirectDrives": {
+                                "type": "boolean",
+                                "default": false,
+                                "description": "Specifies if redirection of disk drives is allowed."
+                            },
+                            "RedirectDevices": {
+                                "type": "boolean",
+                                "default": false,
+                                "description": "Specifies if redirection of devices is allowed."
+                            },
+                            "RedirectSmartCards": {
+                                "type": "boolean",
+                                "default": false,
+                                "description": "Specifies if redirection of smart cards is allowed."
+                            },
+                            "DesktopWidth": {
+                                "type": "integer",
+                                "default": 1024,
+                                "description": "Specifies the initial remote desktop width, in pixels."
+                            },
+                            "DesktopHeight": {
+                                "type": "integer",
+                                "default": 768,
+                                "description": "Specifies the initial remote desktop height, in pixels."
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds user setting schema to the repo and to the file managed by the application. Most editors will identify the `$schema` property and provide autocomplete and descriptions for the properties when editing the file.