### PR TITLE
ux improvements

### DIFF
--- a/VMPlex/MainWindow.xaml
+++ b/VMPlex/MainWindow.xaml
@@ -4,13 +4,17 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:ui="http://schemas.modernwpf.com/2019"
-        xmlns:local="clr-namespace:VMPlex"
+        xmlns:root="clr-namespace:VMPlex"
         mc:Ignorable="d"
         ui:ThemeManager.IsThemeAware="True"
         ui:WindowHelper.UseModernWindowStyle="True"
         ui:TitleBar.ExtendViewIntoTitleBar="True"
         Title="VMPlex Workstation"
-        Height="700" Width="900" MinWidth="1075" MinHeight="650">
+        Width="{Binding Source={x:Static root:UserSettings.Instance}, Path=Settings.MainWindow.Width, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
+        Height="{Binding Source={x:Static root:UserSettings.Instance}, Path=Settings.MainWindow.Height, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
+        MinWidth="1200"
+        MinHeight="900"
+        >
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="32"/>

--- a/VMPlex/MainWindow.xaml.cs
+++ b/VMPlex/MainWindow.xaml.cs
@@ -31,6 +31,35 @@ namespace VMPlex
             System.Windows.Resources.StreamResourceInfo info = Application.GetResourceStream(new Uri("/Resources/VMPlex.ico", UriKind.Relative));
             Icon icon = new Icon(info.Stream, 16, 16);
             TbIcon.Source = System.Windows.Interop.Imaging.CreateBitmapSourceFromHIcon(icon.Handle, Int32Rect.Empty, BitmapSizeOptions.FromEmptyOptions());
+
+            Loaded += MainWindow_Loaded;
+            Closing += MainWindow_Closing;
+        }
+
+        private void MainWindow_Loaded(object sender, object e)
+        {
+            var s = UserSettings.Instance.Settings;
+            Width = s.MainWindow.Width;
+            Height = s.MainWindow.Height;
+            Top = s.MainWindow.Top;
+            Left = s.MainWindow.Left;
+            if (s.MainWindow.State != WindowState.Minimized)
+            {
+                WindowState = s.MainWindow.State;
+            }
+        }
+
+        private void MainWindow_Closing(object sender, object e)
+        {
+            UserSettings.Instance.Mutate(s =>
+            {
+                s.MainWindow.Width = Width;
+                s.MainWindow.Height = Height;
+                s.MainWindow.Top = Top;
+                s.MainWindow.Left = Left;
+                s.MainWindow.State = WindowState;
+                return s;
+            });
         }
     }
 }

--- a/VMPlex/UI/ManagerPage.xaml.cs
+++ b/VMPlex/UI/ManagerPage.xaml.cs
@@ -196,6 +196,26 @@ namespace VMPlex.UI
             return (VirtualMachine)vmList.SelectedItem;
         }
 
+        private bool ConfirmToolBarAction(object Sender, VirtualMachine VM,  string Action)
+        {
+            if (Sender.GetType() != typeof(ModernWpf.Controls.AppBarButton))
+            {
+                return true;
+            }
+
+            if (!UserSettings.Instance.Settings.ConfirmToolBarActions)
+            {
+                return true;
+            }
+
+            var res = UI.MessageBox.Show(
+                MessageBoxImage.Warning,
+                $"{Action} {VM.Name}?",
+                MessageBoxButton.YesNo);
+
+            return res == MessageBoxResult.Yes;
+        }
+
         private void OnPowerCommand(object sender, RoutedEventArgs e)
         {
             VirtualMachine vm = GetSelectedVm();
@@ -211,7 +231,10 @@ namespace VMPlex.UI
             }
             else
             {
-                vm.RequestStateChange(VirtualMachine.StateChange.Disabled);
+                if (ConfirmToolBarAction(sender, vm, "Turn off"))
+                {
+                    vm.RequestStateChange(VirtualMachine.StateChange.Disabled);
+                }
             }
         }
 
@@ -244,7 +267,10 @@ namespace VMPlex.UI
             }
             if (vm.State != IMsvm_ComputerSystem.SystemState.Off)
             {
-                vm.RequestStateChange(VirtualMachine.StateChange.Reset);
+                if (ConfirmToolBarAction(sender, vm, "Reset"))
+                {
+                    vm.RequestStateChange(VirtualMachine.StateChange.Reset);
+                }
             }
         }
 
@@ -267,7 +293,10 @@ namespace VMPlex.UI
             }
             if (vm.State != IMsvm_ComputerSystem.SystemState.Off)
             {
-                vm.RequestStateChange(VirtualMachine.StateChange.Shutdown);
+                if (ConfirmToolBarAction(sender, vm, "Shut down"))
+                {
+                    vm.RequestStateChange(VirtualMachine.StateChange.Shutdown);
+                }
             }
         }
 
@@ -280,7 +309,10 @@ namespace VMPlex.UI
             }
             if (vm.State != IMsvm_ComputerSystem.SystemState.Off)
             {
-                vm.RequestStateChange(VirtualMachine.StateChange.Reboot);
+                if (ConfirmToolBarAction(sender, vm, "Reboot"))
+                {
+                    vm.RequestStateChange(VirtualMachine.StateChange.Reboot);
+                }
             }
         }
 

--- a/VMPlex/UI/VmRdpPage.xaml.cs
+++ b/VMPlex/UI/VmRdpPage.xaml.cs
@@ -124,6 +124,21 @@ namespace VMPlex.UI
             NotifyChange("ErrorMessage");
         }
 
+        private bool ConfirmToolBarAction(string Action)
+        {
+            if (!UserSettings.Instance.Settings.ConfirmToolBarActions)
+            {
+                return true;
+            }
+
+            var res = UI.MessageBox.Show(
+                MessageBoxImage.Warning,
+                $"{Action} {m_vm.Name}?",
+                MessageBoxButton.YesNo);
+
+            return res == MessageBoxResult.Yes;
+        }
+
         private void OnEnhancedChecked(object sender, RoutedEventArgs e)
         {
             if (Parent != null)
@@ -152,7 +167,10 @@ namespace VMPlex.UI
             }
             else
             {
-                m_vm.RequestStateChange(VirtualMachine.StateChange.Disabled);
+                if (ConfirmToolBarAction("Turn off"))
+                {
+                    m_vm.RequestStateChange(VirtualMachine.StateChange.Disabled);
+                }
             }
         }
 
@@ -175,7 +193,10 @@ namespace VMPlex.UI
         {
             if (m_vm.State != IMsvm_ComputerSystem.SystemState.Off)
             {
-                m_vm.RequestStateChange(VirtualMachine.StateChange.Reset);
+                if (ConfirmToolBarAction("Reset"))
+                {
+                    m_vm.RequestStateChange(VirtualMachine.StateChange.Reset);
+                }
             }
         }
 
@@ -188,7 +209,10 @@ namespace VMPlex.UI
         {
             if (m_vm.State != IMsvm_ComputerSystem.SystemState.Off)
             {
-                m_vm.RequestStateChange(VirtualMachine.StateChange.Shutdown);
+                if (ConfirmToolBarAction("Shut down"))
+                {
+                    m_vm.RequestStateChange(VirtualMachine.StateChange.Shutdown);
+                }
             }
         }
 
@@ -196,7 +220,10 @@ namespace VMPlex.UI
         {
             if (m_vm.State != IMsvm_ComputerSystem.SystemState.Off)
             {
-                m_vm.RequestStateChange(VirtualMachine.StateChange.Reboot);
+                if (ConfirmToolBarAction("Reboot"))
+                {
+                    m_vm.RequestStateChange(VirtualMachine.StateChange.Reboot);
+                }
             }
         }
 

--- a/VMPlex/UserSettings.cs
+++ b/VMPlex/UserSettings.cs
@@ -63,6 +63,13 @@ namespace VMPlex
         /// </summary>
         [JsonInclude]
         public List<VmConfig> VirtualMachines { get; set; } = new List<VmConfig>();
+
+        /// <summary>
+        /// Window settings, generally users don't need to edit this. Used to
+        /// persist state of the window.
+        /// </summary>
+        [JsonInclude]
+        public WindowSettings MainWindow { get; set; } = new WindowSettings();
     }
 
     /// <summary>
@@ -195,6 +202,27 @@ namespace VMPlex
         /// </summary>
         [JsonInclude]
         public int DesktopHeight { get; set; } = 768;
+    }
+
+    /// <summary>
+    /// Window settings. 
+    /// </summary>
+    public class WindowSettings
+    {
+        [JsonInclude]
+        public double Width { get; set; } = 1200;
+
+        [JsonInclude]
+        public double Height { get; set; } = 900;
+
+        [JsonInclude]
+        public double Top { get; set; } = -1;
+
+        [JsonInclude]
+        public double Left { get; set; } = -1;
+
+        [JsonInclude]
+        public WindowState State { get; set; } = WindowState.Normal;
     }
 
     public class UserSettings : INotifyPropertyChanged

--- a/VMPlex/UserSettings.cs
+++ b/VMPlex/UserSettings.cs
@@ -30,16 +30,24 @@ namespace VMPlex
         public bool CompactMode { get; set; } = false;
 
         /// <summary>
+        /// Optionally sets the font size for certain elements in the UI. 
+        /// </summary>
+        [JsonInclude]
+        public double FontSize { get; set; } = 14;
+
+        /// <summary>
         /// When starting VMPlex will remember and reopen previously opened tabs.
         /// </summary>
         [JsonInclude]
         public bool RememberTabs { get; set; } = true;
 
         /// <summary>
-        /// Optionally sets the font size for certain elements in the UI. 
+        /// When true certain tool bar actions will prompt for confirmation
+        /// before executing. Like rebooting, shutting down, resetting virtual
+        /// machines.
         /// </summary>
         [JsonInclude]
-        public double FontSize { get; set; } = 14;
+        public bool ConfirmToolBarActions { get; set; } = true;
 
         /// <summary>
         /// Defines the debugger to use when launching one for a given virtual

--- a/VMPlex/UserSettingsSchema.json
+++ b/VMPlex/UserSettingsSchema.json
@@ -18,7 +18,12 @@
             "type": "boolean",
             "default": "true",
             "description": "When starting VMPlex will remember and reopen previously opened tabs."
-        }
+        },
+        "ConfirmToolBarActions": {
+            "type": "boolean",
+            "default": "true",
+            "description": "When true certain tool bar actions will prompt for confirmation. Like rebooting, shutting down, and resetting virtual machines."
+        },
         "Debugger": {
             "type": "string",
             "default": "windbgx",


### PR DESCRIPTION
PR introduces two things in two commits:
- Option is provided (enabled by default) to prompt user for tool bar actions that case VMs to lose state. This aims to help prevent accidentally turning off or resetting a VM by miss-clicking on the tool bar.
- The window position, size, and state is now persisted in the user settings. This enables the program to restore the state.