### PR TITLE
remote desktop connections

### DIFF
--- a/VMPlex/Rdp/RdpOptions.cs
+++ b/VMPlex/Rdp/RdpOptions.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.DirectoryServices.ActiveDirectory;
 using System.Text;
 
 namespace VMPlex
@@ -14,6 +15,7 @@ namespace VMPlex
         {
             // sensible defaults
 
+            Domain = "";
             Server = "localhost";
             Port = 2179;
             DesktopWidth = 1024;
@@ -35,6 +37,7 @@ namespace VMPlex
             AudioCaptureRedirectionMode = false;
         }
 
+        public string Domain { get; set; }
         public string Server { get; set; }
         public int Port { get; set; }
         public int DesktopWidth { get; set; }

--- a/VMPlex/UI/ManagerPage.xaml
+++ b/VMPlex/UI/ManagerPage.xaml
@@ -104,6 +104,12 @@
                 <ui:AppBarSeparator IsCompact="True"/>
                 <ui:AppBarButton x:Name="vmAdd" Icon="Add" ToolTip="Create VM" Click="OnAddCommand" IsTabStop="False" IsCompact="True"/>
                 <ui:AppBarButton x:Name="vmDelete" Icon="Delete" ToolTip="Delete VM" Click="OnDeleteCommand" IsTabStop="False" IsCompact="True"/>
+                <ui:AppBarSeparator IsCompact="True"/>
+                <ui:AppBarButton x:Name="rdpConnect" ToolTip="Remote Desktop Connection" Click="OnRdpConnect" IsTabStop="False" IsCompact="True">
+                    <ui:AppBarButton.Icon>
+                        <ui:FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE8AF;"/>
+                    </ui:AppBarButton.Icon>
+                </ui:AppBarButton>
             </DockPanel>
         </Grid>
         <Grid Grid.Row="1">

--- a/VMPlex/UI/RdpConnectWindow.xaml
+++ b/VMPlex/UI/RdpConnectWindow.xaml
@@ -1,0 +1,18 @@
+﻿<Window x:Class="VMPlex.UI.RdpConnectWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:ui="http://schemas.modernwpf.com/2019"
+        mc:Ignorable="d"
+        Title="VMPlex Workstation"
+        SizeToContent="WidthAndHeight"
+        ResizeMode="NoResize"
+        ui:ThemeManager.IsThemeAware="True"
+        ui:WindowHelper.UseModernWindowStyle="True">
+        <ui:SimpleStackPanel Orientation="Horizontal" Margin="12 10 12 10" Spacing="20">
+            <ui:FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE8AF;"/>
+            <ComboBox Name="ConnectionBox" IsEditable="True" StaysOpenOnEdit="True" Width="250"/>
+            <Button Name="ConnectButton" Content="Connect" Click="ConnectButton_Click"/>
+        </ui:SimpleStackPanel>
+</Window>

--- a/VMPlex/UI/RdpConnectWindow.xaml.cs
+++ b/VMPlex/UI/RdpConnectWindow.xaml.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace VMPlex.UI
+{
+    /// <summary>
+    /// Interaction logic for RdpConnectWindow.xaml
+    /// </summary>
+    public partial class RdpConnectWindow : Window
+    {
+        public new static RdpSettings? Show()
+        {
+            var connections = new List<string>();
+            foreach (var s in UserSettings.Instance.Settings.RdpConnections)
+            {
+                connections.Add(s.Domain.Length > 0 ? s.Domain + "\\" + s.Server : s.Server);
+            }
+
+            return Application.Current.Dispatcher.Invoke(() =>
+            {
+                var window = new RdpConnectWindow(connections);
+
+                window.ShowInTaskbar = true;
+                window.WindowStartupLocation = WindowStartupLocation.CenterScreen;
+
+                foreach (Window owner in Application.Current.Windows)
+                {
+                    if (owner.IsActive && owner.IsMouseOver)
+                    {
+                        window.Owner = owner;
+                        window.ShowInTaskbar = false;
+                        window.WindowStartupLocation = WindowStartupLocation.CenterOwner;
+                        break;
+                    }
+                }
+
+                var res = window.ShowDialog();
+                if (res == null || res != true)
+                {
+                    return null;
+                }
+
+                var strings = window.ConnectionBox.Text.Split('\\');
+                string domain = strings.Length > 1 ? strings[0] : "";
+                string server = strings.Length > 1 ? strings[1] : strings[0];
+
+                return UserSettings.Instance.Settings.RdpConnections.FirstOrDefault(
+                    s => (s.Domain == domain && s.Server == server),
+                    new RdpSettings { Domain = domain, Server = server }
+                    );
+            });
+        }
+
+        private RdpConnectWindow(List<string> ConnectionList)
+        {
+            InitializeComponent();
+            ConnectionBox.ItemsSource = ConnectionList;
+            Loaded += RdpConnectWindow_Loaded;
+        }
+
+        private void RdpConnectWindow_Loaded(object sender, object e)
+        {
+            (ConnectionBox.Template.FindName("PART_EditableTextBox", ConnectionBox) as TextBox).Focus();
+        }
+
+        private void ConnectButton_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+            Close();
+        }
+
+        protected override void OnSourceInitialized(EventArgs e)
+        {
+            base.OnSourceInitialized(e);
+            InvalidateMeasure();
+        }
+    }
+}

--- a/VMPlex/UI/RdpPage.xaml
+++ b/VMPlex/UI/RdpPage.xaml
@@ -1,0 +1,35 @@
+﻿<UserControl x:Class="VMPlex.UI.RdpPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+      xmlns:local="clr-namespace:VMPlex"
+      mc:Ignorable="d">
+
+    <Grid x:Name="contentGrid">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <Grid Grid.Row="0" x:Name="rdpGrid">
+            <Grid.Background>
+                <ImageBrush Stretch="None" TileMode="Tile" Viewport="0,0,100,100" ViewportUnits="Absolute">
+                    <ImageBrush.ImageSource>pack://application:,,,/VMPlex;component/Resources/rdp_session_bg.png</ImageBrush.ImageSource>
+                </ImageBrush>
+            </Grid.Background>
+            <WindowsFormsHost x:Name="rdpHost" Foreground="{x:Null}" Background="Black" HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="Hidden">
+                <local:RdpClient x:Name="rdp" Dock="Fill"/>
+            </WindowsFormsHost>
+            <StackPanel VerticalAlignment="Center">
+            <Label x:Name="connectingText" Content="{Binding PageName}" ContentStringFormat="Connecting to {0}..." Foreground="LightGray" Background="Transparent" FontFamily="Segoe UI" FontSize="18" HorizontalAlignment="Center" Visibility="Hidden"/>
+            <TextBlock x:Name="errorText"
+                   Text="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:UI.RdpPage}}, Path=ErrorMessage}"
+                   TextAlignment="Center"
+                   Foreground="LightGray"
+                   Background="Transparent"
+                   FontFamily="Segoe UI"
+                   FontSize="18"
+                   Visibility="Hidden"/>
+            </StackPanel>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/VMPlex/UI/RdpPage.xaml.cs
+++ b/VMPlex/UI/RdpPage.xaml.cs
@@ -1,0 +1,233 @@
+﻿/*
+ * Copyright (c) 2022 Ira Strawser. All rights reserved.
+ */
+
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Threading;
+using System.Diagnostics;
+using System.ComponentModel;
+
+using HyperV;
+using System.DirectoryServices.ActiveDirectory;
+
+namespace VMPlex.UI
+{
+    /// <summary>
+    /// Interaction logic for RdpPage.xaml
+    /// </summary>
+    public partial class RdpPage : UserControl, INotifyPropertyChanged
+    {
+        private readonly DispatcherTimer m_timer = new DispatcherTimer();
+        public string ErrorMessage { get; private set; }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        public void NotifyChange(string name)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+
+        public RdpPage(RdpSettings settings)
+        {
+            InitializeComponent();
+            Connect(settings);
+        }
+
+        private RdpOptions MakeRdpOptions(RdpSettings settings)
+        {
+            var options = new RdpOptions();
+
+            options.Domain = settings.Domain;
+            options.Server = settings.Server;
+            options.Port = 3389;
+            options.EnhancedSession = settings.DefaultEnhancedSession;
+            options.RedirectClipboard = settings.RedirectClipboard;
+            options.AudioRedirectionMode = (uint)settings.AudioRedirectionMode;
+            options.AudioCaptureRedirectionMode = settings.AudioCaptureRedirectionMode;
+            options.RedirectDrives = settings.RedirectDrives;
+            options.RedirectDevices = settings.RedirectDevices;
+            options.RedirectSmartCards = settings.RedirectSmartCards;
+            options.DesktopWidth = settings.DesktopWidth;
+            options.DesktopHeight = settings.DesktopHeight;
+
+            return options;
+        }
+
+        private void Connect(RdpSettings settings)
+        {
+            rdpHost.Height = rdp.Height;
+            rdpHost.Width = rdp.Width;
+            rdpGrid.SizeChanged += OnGridSizeChanged;
+            rdpHost.DpiChanged += RdpHost_DpiChanged;
+            rdp.DesktopResized += OnRdpDesktopResized;
+
+            rdp.InitializeForRemoteDesktopConnection(MakeRdpOptions(settings));
+
+            m_timer.Tick += OnResizeTimer;
+            rdp.OnRdpConnecting += OnRdpConnecting;
+            rdp.OnRdpConnected += OnRdpConnected;
+            rdp.OnRdpDisconnected += OnRdpDisconnected;
+            rdp.OnRdpError += OnRdpError;
+
+            rdp.Connect();
+        }
+
+        private void DisplayErrorMessage(string message)
+        {
+            ErrorMessage = message;
+            errorText.Visibility = Visibility.Visible;
+            rdpHost.Visibility = Visibility.Hidden;
+            NotifyChange("ErrorMessage");
+        }
+
+        private void HideErrorMessage()
+        {
+            ErrorMessage = "";
+            errorText.Visibility = Visibility.Hidden;
+            NotifyChange("ErrorMessage");
+        }
+
+        private void OnRdpConnecting(object sender)
+        {
+            this.Dispatcher.Invoke(() =>
+            {
+                connectingText.Visibility = Visibility.Visible;
+                rdpHost.Visibility = Visibility.Hidden;
+            });
+        }
+
+        private void OnRdpConnected(object sender)
+        {
+            System.Diagnostics.Debug.Print("Rdp connected");
+            connectingText.Visibility = Visibility.Hidden;
+            rdpHost.Visibility = System.Windows.Visibility.Visible;
+            if (rdp.Enhanced)
+            {
+                StartResizeTimer();
+            }
+        }
+
+        private void OnRdpDisconnected(object sender)
+        {
+            System.Diagnostics.Debug.Print("Rdp disconnected");
+            this.Dispatcher.Invoke(() =>
+            {
+                connectingText.Visibility = Visibility.Hidden;
+                rdpHost.Visibility = System.Windows.Visibility.Hidden;
+                HideErrorMessage();
+            });
+            m_timer.Stop();
+        }
+
+        private void OnRdpError(object sender, RdpClient.RdpError error)
+        {
+            this.Dispatcher.Invoke(() =>
+            {
+                switch(error)
+                {
+                case RdpClient.RdpError.BasicSessionWithShieldedVm:
+                    DisplayErrorMessage("Cannot connect to a shielded virtual machine with a basic session.\nPlease enable the Enhanced Mode option.");
+                    break;
+                }
+            });
+        }
+
+        public void Shutdown()
+        {
+            rdp.Shutdown();
+        }
+
+        public void Disconnect()
+        {
+            System.Diagnostics.Debug.Print("rdp resize timer stopped in Disconnect");
+            m_timer.Stop();
+            try
+            {
+                rdp.Disconnect();
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        // Resize the WindowsFormsHost that contains the RDP ActiveX control taking into account available space
+        // and DPI scaling. This uses the current DesktopSize from the ActiveX control.
+        private void ResizeRdpHost(Size gridSize)
+        {
+            System.Windows.Size rdpSize = rdp.ScaledRdpDesktopSize();
+            double targetWidth = rdpSize.Width;
+            double targetHeight = rdpSize.Height;
+            targetWidth = Math.Min(targetWidth, gridSize.Width);
+            targetHeight = Math.Min(targetHeight, gridSize.Height);
+            if (rdp.EnhancedReady)
+            {
+            }
+            System.Diagnostics.Debug.Print("Resizing rdpHost to {0}, {1}", targetWidth, targetHeight);
+            rdpHost.Width = targetWidth;
+            rdpHost.Height = targetHeight;
+        }
+
+        // Fired when moving between monitors with different DPI scaling or if the monitor/system DPI scaling
+        // settings are changed
+        private void RdpHost_DpiChanged(object sender, DpiChangedEventArgs e)
+        {
+            DpiScale dpi = e.NewDpi;
+
+            Debug.Print("RdpHost_DpiChanged: DpiScaleX: {0} DpiScaleY: {1}",
+                dpi.DpiScaleX, dpi.DpiScaleY);
+
+            System.Diagnostics.Debug.Print("OnSizeChanged: RdpHost_DpiChanged");
+            ResizeRdpHost(new Size(rdpGrid.ActualWidth, rdpGrid.ActualHeight));
+        }
+
+        // Fired when the ActiveX RDP control notifies us the remote desktop size has changed
+        private void OnRdpDesktopResized(object sender, EventArgs e)
+        {
+            ResizeRdpHost(new Size(rdpGrid.ActualWidth, rdpGrid.ActualHeight));
+        }
+
+        // Fired when the grid containing the WindowsFormsHost (which then hosts the RDP ActiveX control) is resized.
+        // We need to check if the WindowsFormsHost needs to be resized to fit within the new available space.
+        private void OnGridSizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            System.Diagnostics.Debug.Print("Rdp grid resized {0}, {1}", e.NewSize.Width, e.NewSize.Height);
+            if (!rdp.EnhancedReady)
+            {
+                ResizeRdpHost(new Size(e.NewSize.Width, e.NewSize.Height));
+            }
+            else
+            {
+                StartResizeTimer();
+            }
+        }
+
+        private void OnResizeTimer(object sender, EventArgs e)
+        {
+            System.Diagnostics.Debug.Print("Rdp resize timer {0} {1}", rdpGrid.ActualWidth, rdpGrid.ActualHeight);
+            if (rdp.IsVideoAvailable() == false || rdp.TryResize(rdpGrid.ActualWidth, rdpGrid.ActualHeight))
+            {
+                rdpHost.Width = rdpGrid.ActualWidth;
+                rdpHost.Height = rdpGrid.ActualHeight;
+                m_timer.Stop();
+                System.Diagnostics.Debug.Print("rdp resize timer stopped in OnResizeTimer");
+                return;
+            }
+        }
+
+        private void StartResizeTimer()
+        {
+            int seconds = 1;
+            int milliseconds = 0;
+            if (rdp.EnhancedReady)
+            {
+                seconds = 0;
+                milliseconds = 200;
+            }
+            System.Diagnostics.Debug.Print("Starting rdp resize timer");
+            m_timer.Stop();
+            m_timer.Interval = new TimeSpan(0, 0, 0, seconds, milliseconds);
+            m_timer.Start();
+        }
+    }
+}

--- a/VMPlex/UserSettings.cs
+++ b/VMPlex/UserSettings.cs
@@ -65,6 +65,13 @@ namespace VMPlex
         public List<VmConfig> VirtualMachines { get; set; } = new List<VmConfig>();
 
         /// <summary>
+        /// List of remote desktop connection settings for connecting to machines
+        /// that aren't Hyper-V managed virtual machines.
+        /// </summary>
+        [JsonInclude]
+        public List<RdpSettings> RdpConnections { get; set; } = new List<RdpSettings>();
+
+        /// <summary>
         /// Window settings, generally users don't need to edit this. Used to
         /// persist state of the window.
         /// </summary>
@@ -122,7 +129,19 @@ namespace VMPlex
     public class RdpSettings
     {
         /// <summary>
-        /// The default enhanced session state when connecting to a virtual machine.
+        /// Domain for the RDP connection.
+        /// </summary>
+        [JsonInclude]
+        public string Domain { get; set; } = "";
+
+        /// <summary>
+        /// Server for the RDP connection.
+        /// </summary>
+        [JsonInclude]
+        public string Server { get; set; } = "localhost";
+
+        /// <summary>
+        /// The default enhanced session state when connecting.
         /// </summary>
         [JsonInclude]
         public bool DefaultEnhancedSession { get; set; } = true;

--- a/VMPlex/UserSettingsSchema.json
+++ b/VMPlex/UserSettingsSchema.json
@@ -57,61 +57,83 @@
                         "description": "Indicates if the virtual machine tab is open and at what index. Used in conjunction with RememberTabs."
                     },
                     "RdpSettings": {
-                        "type": "object",
-                        "description": "Optional RDP settings used when connecting to this virtual machine.",
-                        "properties": {
-                            "DefaultEnhancedSession": {
-                                "type": "boolean",
-                                "default": true,
-                                "description": "The default enhanced session state when connecting to a virtual machine."
-                            },
-                            "RedirectClipboard": {
-                                "type": "boolean",
-                                "default": true,
-                                "description": "Specifies if redirection of the clipboard is allowed."
-                            },
-                            "AudioRedirectionMode": {
-                                "type": "string",
-                                "enum": [
-                                    "Redirect",
-                                    "PlayOnServer",
-                                    "None"
-                                ],
-                                "default": "Redirect",
-                                "description": "Specifies the auto redirection mode."
-                            },
-                            "AudioCaptureRedirectionMode": {
-                                "type": "boolean",
-                                "default": false,
-                                "description": "Specifies if the default audio input device is captured."
-                            },
-                            "RedirectDrives": {
-                                "type": "boolean",
-                                "default": false,
-                                "description": "Specifies if redirection of disk drives is allowed."
-                            },
-                            "RedirectDevices": {
-                                "type": "boolean",
-                                "default": false,
-                                "description": "Specifies if redirection of devices is allowed."
-                            },
-                            "RedirectSmartCards": {
-                                "type": "boolean",
-                                "default": false,
-                                "description": "Specifies if redirection of smart cards is allowed."
-                            },
-                            "DesktopWidth": {
-                                "type": "integer",
-                                "default": 1024,
-                                "description": "Specifies the initial remote desktop width, in pixels."
-                            },
-                            "DesktopHeight": {
-                                "type": "integer",
-                                "default": 768,
-                                "description": "Specifies the initial remote desktop height, in pixels."
-                            }
-                        }
+                        "$ref": "#/$defs/RdpSettings"
                     }
+                }
+            }
+        },
+        "RdpConnections": {
+            "type": "array",
+            "description": "A list of remote desktop connection settings for connecting to machines that aren't Hyper-V managed virtual machines.",
+            "items": {
+                "$ref": "#/$defs/RdpSettings"
+            }
+        }
+    },
+    "$defs": {
+        "RdpSettings": {
+            "type": "object",
+            "description": "Optional RDP settings used when connecting to this virtual machine.",
+            "properties": {
+                "Domain": {
+                    "type": "string",
+                    "default": "",
+                    "description": "The domain to use when connecting, ignored for virtual machines."
+                },
+                "Server": {
+                    "type": "string",
+                    "default": "localhost",
+                    "description": "The the server to connect to, ignored for virtual machines."
+                },
+                "DefaultEnhancedSession": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "The default enhanced session state when connecting."
+                },
+                "RedirectClipboard": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Specifies if redirection of the clipboard is allowed."
+                },
+                "AudioRedirectionMode": {
+                    "type": "string",
+                    "enum": [
+                        "Redirect",
+                        "PlayOnServer",
+                        "None"
+                    ],
+                    "default": "Redirect",
+                    "description": "Specifies the auto redirection mode."
+                },
+                "AudioCaptureRedirectionMode": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Specifies if the default audio input device is captured."
+                },
+                "RedirectDrives": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Specifies if redirection of disk drives is allowed."
+                },
+                "RedirectDevices": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Specifies if redirection of devices is allowed."
+                },
+                "RedirectSmartCards": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Specifies if redirection of smart cards is allowed."
+                },
+                "DesktopWidth": {
+                    "type": "integer",
+                    "default": 1024,
+                    "description": "Specifies the initial remote desktop width, in pixels."
+                },
+                "DesktopHeight": {
+                    "type": "integer",
+                    "default": 768,
+                    "description": "Specifies the initial remote desktop height, in pixels."
                 }
             }
         }


### PR DESCRIPTION
I found myself wishing that VMPlex could handle a normal remote desktop session. VMPlex is very good at display and resizing the RDP content and organizing tabs. At times I want to remote into machines and at the same time manage a set of local virtual machines in one set of tabs.

This PR implements the ability to create and connect to an RDP session:
![image](https://user-images.githubusercontent.com/11687482/231856815-9c23331f-4d09-438e-b88a-7a6a428e469a.png)

Once connected a new tab is created alongside other virtual machine tabs, the icon distinguishes it from virtual machines:
![image](https://user-images.githubusercontent.com/11687482/231857423-839b78c8-6a31-4443-82c7-cf4e0355eb88.png)

The user settings file is adjusted to allow configuring the different remote desktop connections. These are updated/saved when the user first connects to a new machine, users may also create them themselves manually, if they wish. This is also the location to remove remote connections the user no longer wants tracked/saved or saved:
```json
  "RdpConnections": [
    {
      "Domain": "",
      "Server": "jxy-desktop",
      "DefaultEnhancedSession": true,
      "RedirectClipboard": true,
      "AudioRedirectionMode": "Redirect",
      "AudioCaptureRedirectionMode": false,
      "RedirectDrives": false,
      "RedirectDevices": false,
      "RedirectSmartCards": false,
      "DesktopWidth": 1024,
      "DesktopHeight": 768
    },
    {
      "Domain": "",
      "Server": "jxy-arm",
      "DefaultEnhancedSession": true,
      "RedirectClipboard": true,
      "AudioRedirectionMode": "Redirect",
      "AudioCaptureRedirectionMode": false,
      "RedirectDrives": false,
      "RedirectDevices": false,
      "RedirectSmartCards": false,
      "DesktopWidth": 1024,
      "DesktopHeight": 768
    }
  ],

```