### PR TITLE
install support

### DIFF
--- a/VMPlex/App.xaml.cs
+++ b/VMPlex/App.xaml.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Diagnostics;
+using System.IO;
 using System.Windows;
+using IWshRuntimeLibrary;
 
 namespace VMPlex
 {
@@ -10,6 +13,7 @@ namespace VMPlex
     {
         protected override void OnStartup(StartupEventArgs e)
         {
+            HandleCommandLine();
             LoadUserSettings();
             Utility.TryExtractHVIntegrate();
             base.OnStartup(e);
@@ -34,6 +38,124 @@ namespace VMPlex
                 //
                 Environment.Exit(1);
             }
+        }
+
+        private void HandleCommandLine()
+        {
+            var args = Environment.GetCommandLineArgs();
+            if (args.Length < 2)
+            {
+                return;
+            }
+
+            switch (args[1])
+            {
+                case "--install":
+                {
+                    ActAsInstaller();
+                    break;
+                }
+                case "--upgrade":
+                {
+                    ActAsUpgrader();
+                    break;
+                }
+                case "--uninstall":
+                {
+                    ActAsUninstaller();
+                    break;
+                }
+            }
+        }
+
+        private const string ProgramName = "VMPlex Workstation";
+        private const string ProgramNameShort = "VMPlex";
+        private const string ProgramExe = ProgramNameShort + ".exe";
+        private const string ProgramLnk = ProgramName + ".lnk";
+
+        private string GetProgramDirectory()
+        {
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), 
+                "Programs", 
+                ProgramName);
+        }
+
+        private string GetStartMenuDirectory()
+        {
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.StartMenu),
+                "Programs");
+        }
+
+
+        private void ActAsInstaller()
+        {
+            var programDir = GetProgramDirectory();
+            var startMenu = GetStartMenuDirectory();
+            var program = Path.Combine(programDir, ProgramExe);
+
+            try
+            {
+                if (!Directory.Exists(programDir))
+                    Directory.CreateDirectory(programDir);
+                if (!Directory.Exists(startMenu))
+                    Directory.CreateDirectory(startMenu);
+
+                System.IO.File.Copy(Process.GetCurrentProcess().MainModule.FileName, program);
+
+                var shell = new WshShell();
+                var shortcut = (IWshShortcut)shell.CreateShortcut(Path.Combine(startMenu, ProgramLnk));
+                shortcut.Description = ProgramName;
+                shortcut.TargetPath = program;
+                shortcut.WorkingDirectory = programDir;
+                shortcut.Save();
+            }
+            catch (Exception e)
+            {
+                Debug.Print($"Failed to install: {e.Message}");
+                Environment.Exit(e.HResult != 0 ? e.HResult : 1);
+            }
+
+            Environment.Exit(0);
+        }
+
+        private void ActAsUpgrader()
+        {
+            var programDir = GetProgramDirectory();
+            var program = Path.Combine(programDir, ProgramExe);
+
+            try
+            {
+                System.IO.File.Copy(Process.GetCurrentProcess().MainModule.FileName, program, true);
+            }
+            catch (Exception e)
+            {
+                Debug.Print($"Failed to upgrade: {e.Message}");
+                Environment.Exit(e.HResult != 0 ? e.HResult : 1);
+            }
+
+            Environment.Exit(0);
+        }
+
+        private void ActAsUninstaller()
+        {
+            var programDir = GetProgramDirectory();
+            var shortcut = Path.Combine(GetStartMenuDirectory(), ProgramLnk);
+            try
+            {
+                if (Directory.Exists(programDir))
+                    Directory.Delete(programDir, true);
+                if (System.IO.File.Exists(shortcut))
+                    System.IO.File.Delete(shortcut);
+            }
+            catch (Exception e)
+            {
+                Debug.Print($"Failed to uninstall: {e.Message}");
+                Environment.Exit(e.HResult != 0 ? e.HResult : 1);
+            }
+
+            Environment.Exit(0);
         }
     }
 }

--- a/VMPlex/VMPlex.csproj
+++ b/VMPlex/VMPlex.csproj
@@ -54,6 +54,17 @@
     <None Remove="Resources\rdp_session_bg.png" />
   </ItemGroup>
   <ItemGroup>
+    <COMReference Include="IWshRuntimeLibrary">
+      <WrapperTool>tlbimp</WrapperTool>
+      <VersionMinor>0</VersionMinor>
+      <VersionMajor>1</VersionMajor>
+      <Guid>f935dc20-1cf0-11d0-adb9-00c04fd58a0b</Guid>
+      <Lcid>0</Lcid>
+      <Isolated>false</Isolated>
+      <EmbedInteropTypes>true</EmbedInteropTypes>
+    </COMReference>
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\EasyWMI\EasyWMI.csproj" />
   </ItemGroup>
   <Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">


### PR DESCRIPTION
Implements `--install`, `--uninstall`, and `--upgrade` in preparation for winget support. I had considered using an MSI or MSIX, but we're already effectively a self contained binary. And the complexity and headache associated with MSI/MSIX is a pain in the ass. We effectively just need to copy ourselves to a programs folder, and create a start menu shortcut. This does that.