### PR TITLE
handle case where hyper-v isn't enabled

### DIFF
--- a/VMPlex/App.xaml.cs
+++ b/VMPlex/App.xaml.cs
@@ -30,9 +30,18 @@ namespace VMPlex
             // Before we show any other windows check that we can access the
             // management service, if we can't then exit.
             //
-            var vsms = new WmiScope(@"root\virtualization\v2")
-                .GetInstance<IMsvm_VirtualSystemManagementService>();
-            if (vsms == null)
+            bool capable = false;
+            try
+            {
+                var vsms = new WmiScope(@"root\virtualization\v2")
+                    .GetInstance<IMsvm_VirtualSystemManagementService>();
+                capable = (vsms != null);
+            }
+            catch
+            {
+            }
+
+            if (!capable)
             {
                 UI.MessageBox.Show(
                    System.Windows.MessageBoxImage.Error,


### PR DESCRIPTION
When Hyper-V isn't installed/enabled on the machine retrieving the `IMsvm_VirtualSystemManagementService` would throw an exception. This was reported during the submission to winget by @stephengillie here: https://github.com/microsoft/winget-pkgs/pull/102646

This change ensures that if the machine is not configured properly and VMPlex is incapable of operating on the machine, the application will display the warning dialog and exit cleanly, instead of crashing.