### PR TITLE
fix column header width crash

### DIFF
--- a/VMPlex/UserSettings.cs
+++ b/VMPlex/UserSettings.cs
@@ -438,6 +438,7 @@ namespace VMPlex
         {
             WriteIndented = true,
             IncludeFields = true,
+            NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals,
             Converters =
             {
                 new JsonStringEnumConverter()


### PR DESCRIPTION
Fixes https://github.com/0xf005ba11/vmplex-ws/issues/56 - the serialization didn't support "NaN" and when clicking the column header it sets with `Width` property to `NaN` which the system interprets as auto-sizing the width of the column. The persistence would crash since we were not specifying to allow this type of serialization. The fix it to allow it.

As a note, and interestingly, the dialog also has an `ActualWidth` property. Which allows you to get the actual width of the column if `Width` is `NaN`.