### PR TITLE
Fix leak (partial fix)

### DIFF
--- a/EasyWMI/EasyWMI.csproj
+++ b/EasyWMI/EasyWMI.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Management" Version="7.0.0" />
+    <PackageReference Include="System.Management" Version="7.0.2" />
   </ItemGroup>
 
 </Project>

--- a/VMPlex.sln
+++ b/VMPlex.sln
@@ -10,7 +10,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VMPlex", "VMPlex\VMPlex.csp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "hvintegrate", "hvintegrate\hvintegrate.csproj", "{FDDD2BF0-12B3-4E6A-A346-922C4C82A999}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyWMI", "EasyWMI\EasyWMI.csproj", "{025DE6E0-ED82-4926-8321-B3C28F14F486}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EasyWMI", "EasyWMI\EasyWMI.csproj", "{025DE6E0-ED82-4926-8321-B3C28F14F486}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/VMPlex/UI/RdpPage.xaml.cs
+++ b/VMPlex/UI/RdpPage.xaml.cs
@@ -34,6 +34,37 @@ namespace VMPlex.UI
             Connect(settings);
         }
 
+        private void UserControl_Unloaded(object sender, RoutedEventArgs e)
+        {
+            //
+            // Make sure all the callbacks are removed so disposal works.
+            //
+            rdpGrid.SizeChanged -= OnGridSizeChanged;
+            rdpHost.DpiChanged -= RdpHost_DpiChanged;
+            rdp.DesktopResized -= OnRdpDesktopResized;
+            rdp.OnRdpConnecting -= OnRdpConnecting;
+            rdp.OnRdpConnected -= OnRdpConnected;
+            rdp.OnRdpDisconnected -= OnRdpDisconnected;
+            rdp.OnRdpError -= OnRdpError;
+
+            //
+            // https://social.msdn.microsoft.com/Forums/vstudio/en-US/b41a3943-1194-43d7-973b-e5bc8fbb5282/severe-memory-leaks?forum=wpf
+            // When mixing Windows Forms and WPF to make sure the ElementHost
+            // or WindowsFormsHost is disposed, or you could leak resources.
+            // Windows Forms will dispose an ElementHost when the non-modal
+            // Form it’s on closes; WPF will dispose a WindowsFormsHost if your
+            // application shuts down.  (Really the interop-specific bit here
+            // is that you could show a WindowsFormsHost on a Window in a
+            // Windows Forms message loop and never get that your Application
+            // is shutting down.)"
+            //
+            // But before disposing the WindowsFormsHost in several cases you
+            // should clear the UIElement that contains it for example the Grid:
+            //
+            rdpGrid.Children.Clear();
+            rdpHost.Dispose();
+        }
+
         private RdpOptions MakeRdpOptions(RdpSettings settings)
         {
             var options = new RdpOptions();

--- a/VMPlex/UI/VmRdpPage.xaml.cs
+++ b/VMPlex/UI/VmRdpPage.xaml.cs
@@ -48,6 +48,38 @@ namespace VMPlex.UI
             Connect(startupEnhanceState);
         }
 
+        private void UserControl_Unloaded(object sender, RoutedEventArgs e)
+        {
+            //
+            // Make sure all the callbacks are removed so disposal works.
+            //
+            rdpGrid.SizeChanged -= OnGridSizeChanged;
+            rdpHost.DpiChanged -= RdpHost_DpiChanged;
+            rdp.DesktopResized -= OnRdpDesktopResized;
+            rdp.OnRdpConnecting -= OnRdpConnecting;
+            rdp.OnRdpConnected -= OnRdpConnected;
+            rdp.OnRdpDisconnected -= OnRdpDisconnected;
+            rdp.OnRdpError -= OnRdpError;
+            m_vm.PropertyChanged -= VmModel_PropertyChanged;
+
+            //
+            // https://social.msdn.microsoft.com/Forums/vstudio/en-US/b41a3943-1194-43d7-973b-e5bc8fbb5282/severe-memory-leaks?forum=wpf
+            // When mixing Windows Forms and WPF to make sure the ElementHost
+            // or WindowsFormsHost is disposed, or you could leak resources.
+            // Windows Forms will dispose an ElementHost when the non-modal
+            // Form it’s on closes; WPF will dispose a WindowsFormsHost if your
+            // application shuts down.  (Really the interop-specific bit here
+            // is that you could show a WindowsFormsHost on a Window in a
+            // Windows Forms message loop and never get that your Application
+            // is shutting down.)"
+            //
+            // But before disposing the WindowsFormsHost in several cases you
+            // should clear the UIElement that contains it for example the Grid:
+            //
+            rdpGrid.Children.Clear();
+            rdpHost.Dispose();
+        }
+
         private RdpOptions MakeRdpOptions()
         {
             var options = new RdpOptions();

--- a/VMPlex/VMPlex.csproj
+++ b/VMPlex/VMPlex.csproj
@@ -37,9 +37,9 @@
     <OutputPath>..\bin\Release\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Devolutions.MsRdpEx" Version="2022.12.8" />
+    <PackageReference Include="Devolutions.MsRdpEx" Version="2023.9.28" />
     <PackageReference Include="Dirkster.InplaceEditBoxLib" Version="1.4.2" />
-    <PackageReference Include="ModernWpfUI" Version="0.9.5" />
+    <PackageReference Include="ModernWpfUI" Version="0.9.6" />
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Resources\rdp_session_bg.png" />


### PR DESCRIPTION
Two commits here, first just updates the packages.

Second commit is a partial fix to attempt to address the ActiveX leak. This fix is incomplete. It _does_ fix VMPlex leaking the `VmRdpPage` and `RdpPage` objects. However the `WindowsFormsHost` is still leaked. I believe this is due to a bug inside of the .NET `AxHost`.

This path is fixed, `VmRdpPage` (and `RdpPage`) is now garbage collected:
![image](https://github.com/0xf005ba11/vmplex-ws/assets/11687482/2b348923-941e-40a0-9bb3-c3b79d4ab2fb)

However, these objects are still leaked:
![image](https://github.com/0xf005ba11/vmplex-ws/assets/11687482/fff31326-767f-4dab-afee-b76ddc126417)
![image](https://github.com/0xf005ba11/vmplex-ws/assets/11687482/056698f7-c7e3-4ea0-bbb1-49f17a5dc9e8)

To express the leak simply activate and deactivate RDP sessions, either by opening and closing VM tabs, or enabling/disabling enhanced mode.

There are a few things I tried to resolve this problem ourselves. There was a leak of `eventMulticaster` inside of `AxMsRdpClient9NotSafeForScripting`. I went as far as copying and patching that interface manually to ensure that `eventMulticaster` is released when dispose is called. That fixed part of the issue, but I ran into the other leaks above (see screenshot)... At which point I started down the path of copying the implementations of `AxHost` and `AxHostEx` to try to patch it and I just ran out of steam... a bug should probably be submitted to have this fixed.

Regardless, I believe this patch is a reasonable to at least partially fix the leak.