### PR TITLE
Various fixes and UI improvements

### DIFF
--- a/VMPlex/UI/VmRdpPage.xaml.cs
+++ b/VMPlex/UI/VmRdpPage.xaml.cs
@@ -140,6 +140,9 @@ namespace VMPlex.UI
             }
             vmEnhancedMode.Checked += OnEnhancedChecked;
             vmEnhancedMode.Unchecked += OnEnhancedUnchecked;
+
+            vmCtrlAltDel.IsEnabled = !(bool)vmEnhancedMode.IsChecked;
+            vmTypeClipboard.IsEnabled = !(bool)vmEnhancedMode.IsChecked;
         }
 
         private void DisplayErrorMessage(string message)
@@ -192,8 +195,8 @@ namespace VMPlex.UI
 
         private void OnPowerCommand(object sender, RoutedEventArgs e)
         {
-            if (m_vm.State == IMsvm_ComputerSystem.SystemState.Off || 
-                m_vm.State == IMsvm_ComputerSystem.SystemState.Saved || 
+            if (m_vm.State == IMsvm_ComputerSystem.SystemState.Off ||
+                m_vm.State == IMsvm_ComputerSystem.SystemState.Saved ||
                 m_vm.State == IMsvm_ComputerSystem.SystemState.Paused)
             {
                 m_vm.RequestStateChange(VirtualMachine.StateChange.Enabled);

--- a/VMPlex/VMPlex.csproj
+++ b/VMPlex/VMPlex.csproj
@@ -39,7 +39,7 @@
   <ItemGroup>
     <PackageReference Include="Devolutions.MsRdpEx" Version="2023.9.28" />
     <PackageReference Include="Dirkster.InplaceEditBoxLib" Version="1.4.2" />
-    <PackageReference Include="ModernWpfUI" Version="0.9.6" />
+    <PackageReference Include="ModernWpfUI" Version="0.9.5" />
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Resources\rdp_session_bg.png" />

--- a/VMPlex/VirtualMachine.cs
+++ b/VMPlex/VirtualMachine.cs
@@ -141,7 +141,8 @@ namespace VMPlex
 
         public void TypeCtrlAltDel()
         {
-            Keyboard.TypeCtrlAltDel();
+            if (Keyboard != null)
+                Keyboard.TypeCtrlAltDel();
         }
 
         public void OpenDebugger()
@@ -226,7 +227,8 @@ namespace VMPlex
 
         public void TypeText(string text)
         {
-            Keyboard.TypeText(text);
+            if (Keyboard != null)
+                Keyboard.TypeText(text);
         }
 
         public bool IsVideoAvailable()


### PR DESCRIPTION
f6b29fec07438932c8caf7a6239fd13bf2a8e4b3 - This fixes a crash that can happen when the `Keyboard` property is null, the keyboard property can be null when the VM is in a non-active state.
f12bf79656416a6b77db7b8aba95e99dff617db9 - Upgrading the ModernWfpUI package introduced a white screen bug when switching between enhanced and regular modes, this bug should probably be reported upstream, but we will revert to the previous version for now.
ceef651487c124d6027bb0165924e21c21194764 - The keyboard app buttons for ctrl+alt+del and typing the clipboard do not make sense in an enhanced session as they don't send the keyboard input. To avoid confusion, this disables them if the RDP session is enhanced and enables them otherwise.