### PR TITLE
Add status text to vm page

### DIFF
--- a/VMPlex/UI/VmRdpPage.xaml
+++ b/VMPlex/UI/VmRdpPage.xaml
@@ -1,8 +1,8 @@
 ﻿<UserControl x:Class="VMPlex.UI.VmRdpPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:local="clr-namespace:VMPlex"
       xmlns:ui="http://schemas.modernwpf.com/2019"
       mc:Ignorable="d">
@@ -86,6 +86,8 @@
                 <TextBlock Text="CPU: " VerticalAlignment="Center" DockPanel.Dock="Right"/>
                 <ui:AppBarSeparator IsCompact="True" DockPanel.Dock="Right"/>
                 <TextBlock Text="{Binding MemoryUsage,StringFormat='{}{0} MB'}" VerticalAlignment="Center" DockPanel.Dock="Right"/>
+                <ui:AppBarSeparator IsCompact="True" DockPanel.Dock="Right"/>
+                <TextBlock Text="{Binding StatusText}" VerticalAlignment="Center" DockPanel.Dock="Right"/>
                 <ui:AppBarSeparator IsCompact="True" DockPanel.Dock="Right" Visibility="Hidden"/>
             </DockPanel>
         </Grid>


### PR DESCRIPTION
This PR adds the status text to the VM page so you can immediately see the status for things like merging or creating checkpoints.

![image](https://github.com/0xf005ba11/vmplex-ws/assets/11687482/8f5c6a14-f730-4cea-b3ff-68644d47b43a)

![image](https://github.com/0xf005ba11/vmplex-ws/assets/11687482/e630837a-6154-4803-856e-287031ff4992)
